### PR TITLE
i898 - Increase worker disk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Use the `"CI system"` component in [YouTrack](https://vimc.myjetbrains.com/youtr
 1. Install in the host machine:
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 * [Vagrant](https://www.vagrantup.com/downloads.html)
+* [vagrant-disksize](https://github.com/sprotheroe/vagrant-disksize) (`vagrant plugin install vagrant-disksize`)
 
 2. Clone this repository.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ backup =
 # let's pull it out into its own thing for now
 server_data_disk = 'server_data_disk.vdi'
 server_data_disk_size = 30 # in GB
+worker_disk_size = 100 # in GB
 
 Vagrant.configure(2) do |config|
   # Common bits:
@@ -87,6 +88,7 @@ Vagrant.configure(2) do |config|
       agent_config.vm.provider :virtualbox do | vbox |
         vbox.gui = false
         vbox.memory = agent[:ram]
+        config.disksize.size = "#{worker_disk_size}GB"
       end
       agent_config.vm.hostname = agent[:hostname] + '.' + domain
       agent_config.vm.network :private_network, ip: agent[:ip]


### PR DESCRIPTION
From my local testing this will resize existing workers disks so this should
just require a reboot of the workers to take effect.  The original size is
40GB and I've gone with 100GB here - we can always increase later.  I think
that we should still solve VIMC-612 though as this just defers the problem