### PR TITLE
i1116 - CI server maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ From the host, as root, run the script `./scripts/write-cron-teamcity-backup-syn
 
 To restore the server into a *freshly created machine, during provisioning*, run
 
-    $ ln -s TeamCity_Backup.zip restore/montagu-ci-server
+    $ ln -s TeamCity_Backup.zip shared/restore/montagu-restore.zip
     $ vagrant up montagu-ci-server
     $ rm restore/montagu-ci-server
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,11 @@ which of course needs to be done for all the running machines
 
 The CI server will backup every day into `/opt/TeamCity/data/backup`
 
-From the host, as root, run the script `./scripts/write-cron-teamcity-backup-sync.sh` to write out a cron job that will organise syncing backups every night.  This will create backups in `/vagrant/teamcity` (edit `scripts/sync-backups.sh` to change) as well as creating a link to the most recent backup in `restore`.
+From the host, as root, run the script `./scripts/write-cron-teamcity-backup-sync.sh` to write out a cron job that will organise syncing backups every night.  This will create backups in `/montagu/teamcity` as well as creating a link to the most recent backup in `shared/restore`
 
 To restore the server into a *freshly created machine, during provisioning*, run
 
-    $ ln -s TeamCity_Backup.zip shared/restore/montagu-restore.zip
     $ vagrant up montagu-ci-server
-    $ rm restore/montagu-ci-server
 
 To test that the restore works, run
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a Vagrant setup for creating a TeamCity server and build agents. It uses a shell script for provisioning.
 
+Our teamcity server runs at http://support.montagu.dide.ic.ac.uk:8111
+
 This was based off of [this repo](https://github.com/rodm/teamcity-vagrant) but has been totally rewritten follow the recommended installation approach for TeamCity 10.x
 
 ## Issues
@@ -80,7 +82,7 @@ To test that the restore works, run
 
     $ vagrant up montagu-ci-backup
 
-which will open a new instance of TeamCity server with the most recently backed up (and synchronised) data.  It will be available on port 8112 (it will have no agents though as they register themselves with the main host).  As with the main server, it will take 1-2 minutes for the login page to work after provisioning is complete.
+which will open a new instance of TeamCity server with the most recently backed up (and synchronised) data.  It will be available at http://support.montagu.dide.ic.ac.uk:8112 (it will have no agents though as they register themselves with the main host).  As with the main server, it will take 1-2 minutes for the login page to work after provisioning is complete.
 
 ## Logging into the machines
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Vagrant setup for creating a TeamCity server and build agents. It uses a shell script for provisioning.
 
-Our teamcity server runs at http://support.montagu.dide.ic.ac.uk:8111
+Our teamcity server runs at http://teamcity.montagu.dide.ic.ac.uk:8111
 
 This was based off of [this repo](https://github.com/rodm/teamcity-vagrant) but has been totally rewritten follow the recommended installation approach for TeamCity 10.x
 
@@ -82,7 +82,7 @@ To test that the restore works, run
 
     $ vagrant up montagu-ci-backup
 
-which will open a new instance of TeamCity server with the most recently backed up (and synchronised) data.  It will be available at http://support.montagu.dide.ic.ac.uk:8112 (it will have no agents though as they register themselves with the main host).  As with the main server, it will take 1-2 minutes for the login page to work after provisioning is complete.
+which will open a new instance of TeamCity server with the most recently backed up (and synchronised) data.  It will be available at http://teamcity.montagu.dide.ic.ac.uk:8112 (it will have no agents though as they register themselves with the main host).  As with the main server, it will take 1-2 minutes for the login page to work after provisioning is complete.
 
 ## Logging into the machines
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,7 @@ backup =
 # This is the thing that will significantly change size over time, so
 # let's pull it out into its own thing for now
 server_data_disk = 'server_data_disk.vdi'
+backup_data_disk = 'backup_data_disk.vdi'
 server_data_disk_size = 60 # in GB
 
 Vagrant.configure(2) do |config|
@@ -71,11 +72,22 @@ Vagrant.configure(2) do |config|
   config.vm.define backup[:hostname] do |backup_config|
     backup_config.vm.provider :virtualbox do |vbox|
       vbox.gui = false
+      unless File.exist?(backup_data_disk)
+        vbox.customize ['createhd', '--filename', backup_data_disk,
+                        '--variant', 'Fixed',
+                        '--size', backup_data_disk_size * 1024]
+      end
       vbox.memory = backup[:ram]
+      vbox.customize ['storageattach', :id, '--storagectl', 'SATA Controller',
+                      '--port', 1, '--device', 0, '--type', 'hdd',
+                      '--medium', backup_data_disk]
     end
     backup_config.vm.hostname = backup[:hostname] + '.' + domain
     backup_config.vm.network :private_network, ip: backup[:ip]
     backup_config.vm.network "forwarded_port", guest: 8111, host: 8112
+    server_config.vm.provision :shell do |shell|
+      shell.path = 'provision/setup-server-disk.sh'
+    end
     backup_config.vm.provision :shell do |shell|
       shell.path = 'provision/setup-server.sh'
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,7 +75,7 @@ Vagrant.configure(2) do |config|
       unless File.exist?(backup_data_disk)
         vbox.customize ['createhd', '--filename', backup_data_disk,
                         '--variant', 'Fixed',
-                        '--size', backup_data_disk_size * 1024]
+                        '--size', server_data_disk_size * 1024]
       end
       vbox.memory = backup[:ram]
       vbox.customize ['storageattach', :id, '--storagectl', 'SATA Controller',

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,7 +85,7 @@ Vagrant.configure(2) do |config|
     backup_config.vm.hostname = backup[:hostname] + '.' + domain
     backup_config.vm.network :private_network, ip: backup[:ip]
     backup_config.vm.network "forwarded_port", guest: 8111, host: 8112
-    server_config.vm.provision :shell do |shell|
+    backup_config.vm.provision :shell do |shell|
       shell.path = 'provision/setup-server-disk.sh'
     end
     backup_config.vm.provision :shell do |shell|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ backup =
 # This is the thing that will significantly change size over time, so
 # let's pull it out into its own thing for now
 server_data_disk = 'server_data_disk.vdi'
-server_data_disk_size = 30 # in GB
+server_data_disk_size = 60 # in GB
 
 Vagrant.configure(2) do |config|
   # Common bits:

--- a/provision/setup-server.sh
+++ b/provision/setup-server.sh
@@ -21,7 +21,7 @@ TEAMCITY_BACKUP="/vagrant/restore/TeamCity_Backup.zip"
 TEAMCITY_DIR=/opt/TeamCity
 TEAMCITY_DATA_DIR=${TEAMCITY_DIR}/data
 
-TEAMCITY_VERSION=2017.1.2
+TEAMCITY_VERSION=2017.2
 TEAMCITY_TGZ=TeamCity-${TEAMCITY_VERSION}.tar.gz
 TEAMCITY_URL=http://download.jetbrains.com/teamcity/$TEAMCITY_TGZ
 

--- a/provision/setup-server.sh
+++ b/provision/setup-server.sh
@@ -12,7 +12,7 @@ TEAMCITY_DB_PASS=teamcity
 TEAMCITY_USER=teamcity
 TEAMCITY_GROUP=teamcity
 
-TEAMCITY_BACKUP="/vagrant/restore/teamcity-restore.zip"
+TEAMCITY_BACKUP="/vagrant/restore/TeamCity_Backup.zip"
 
 # NOTE: The TEAMCITY_DIR variable _must_ end in TeamCity unless some
 # faffage is done because that's the top level name in the tgz.  It's

--- a/scripts/sync-backups.sh
+++ b/scripts/sync-backups.sh
@@ -9,7 +9,6 @@ if [ ! -f .ssh/config ]; then
 fi
 
 RESTORE_LATEST=TeamCity_Backup.zip
-RESTORE_TEST=montagu-ci-backup.zip
 RESTORE_DIR=shared/restore
 # relative from the restore directory
 BACKUP_DIR=/montagu/teamcity
@@ -20,12 +19,11 @@ rsync -av --rsh="ssh -F ${PWD}/.ssh/config" \
 
 LAST_BACKUP=$(ls $BACKUP_DIR | tail -n1)
 
-rm -f $RESTORE_DIR/$RESTORE_LATEST $RESTORE_DIR/$RESTORE_TEST
+rm -f $RESTORE_DIR/$RESTORE_LATEST
 
 if [ ! -z $LAST_BACKUP ]; then
     echo "Setting $LAST_BACKUP as current backup"
     cp $BACKUP_DIR/$LAST_BACKUP $RESTORE_DIR/$RESTORE_LATEST
-    ln -s $RESTORE_LATEST $RESTORE_DIR/$RESTORE_TEST
 else
     echo "No backup exists; not creating link"
 fi


### PR DESCRIPTION
This PR does three maintenance tasks, lumped together to avoid disruption and to make it easy to do a dry run

* increase disk size
* restore test also needs a test disk
* update the teamcity version

We were running short of space on the teamcity disk (which was 30GB).  I've increased this to 60GB but subsequently noticed that the main reason was that the local copy of the backups were not thinned.  I've left the larger size in here though because it increases the time we don't have to think about it.

I've tested both the upgrade and the restore using the `montagu-ci-backup` machine.  Running `vagrant up montagu-ci-backup` is confirmed to restore our system (which is what I was trying to test in the first place).  The documentation was out of date so this adds a fourth thing to the PR

* fix the documentation for the CI restore