### PR TITLE
i1264 - Fix backup on teamcity

### DIFF
--- a/shared/files/server/teamcity-backup
+++ b/shared/files/server/teamcity-backup
@@ -13,4 +13,5 @@ TEAMCITY_GROUP={{TEAMCITY_GROUP}}
 export JAVA_HOME=/usr/lib/jvm/java-8-oracle
 $TEAMCITY_DIR/bin/maintainDB.sh backup -C -D -L -P -U -A $TEAMCITY_DATA_DIR
 chown -R $TEAMCITY_USER:$TEAMCITY_GROUP $TEAMCITY_DATA_DIR/backup
+chmod 755 $TEAMCITY_DATA_DIR/backup
 chmod 444 $TEAMCITY_DATA_DIR/backup/*.zip


### PR DESCRIPTION
Set permissions as 755 on backup directory

I think that superuser picked up a more restrictive umask in the ubuntu
upgrade and that caused the backup directory to have permissions 750 (not 755).

This restores the more permissive permissions, allowing the backup sync to
work from the support.montagu host machine

I have run this fix manually on the server but verified that it works with the test restore vm