### PR TITLE
i1366: Allow TeamCity agent to restart docker service.

### DIFF
--- a/provision/setup-agent-users.sh
+++ b/provision/setup-agent-users.sh
@@ -8,3 +8,6 @@ TEAMCITY_USER=teamcity
 TEAMCITY_GROUP=teamcity
 /usr/sbin/groupadd -r $TEAMCITY_GROUP 2>/dev/null
 /usr/sbin/useradd -c $TEAMCITY_USER -r -s /bin/bash -d $TEAMCITY_DIR -g $TEAMCITY_GROUP $TEAMCITY_USER 2>/dev/null
+
+echo "%teamcity ALL=NOPASSWD: /bin/systemctl restart docker" \
+	| sudo tee /etc/sudoers.d/teamcity

--- a/provision/setup-agent-users.sh
+++ b/provision/setup-agent-users.sh
@@ -9,5 +9,9 @@ TEAMCITY_GROUP=teamcity
 /usr/sbin/groupadd -r $TEAMCITY_GROUP 2>/dev/null
 /usr/sbin/useradd -c $TEAMCITY_USER -r -s /bin/bash -d $TEAMCITY_DIR -g $TEAMCITY_GROUP $TEAMCITY_USER 2>/dev/null
 
+# This grants the teamcity group permission to restart Docker
+# via sudo without needing a password. This is needed for the
+# Montagu repo build, which restarts the Docker daemon to simulate
+# a reboot.
 echo "%teamcity ALL=NOPASSWD: /bin/systemctl restart docker" \
 	| sudo tee /etc/sudoers.d/teamcity


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1366