### PR TITLE
use openjdk

### DIFF
--- a/provision/install-java.sh
+++ b/provision/install-java.sh
@@ -1,26 +1,13 @@
 #!/bin/sh
 
 set -x
-JAVA_HOME=/usr/lib/jvm/java-8-oracle
-JAVA_CACHE_VAGRANT=/vagrant/downloads/java
-JAVA_CACHE_SYSTEM=/var/cache/oracle-jdk8-installer
+JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 if [ -d $JAVA_HOME ]; then
     echo "Java is already installed"
     exit 0
 fi
 
-if [ -d $JAVA_CACHE_VAGRANT ]; then
-    rsync -av $JAVA_CACHE_VAGRANT/ `dirname $JAVA_CACHE_SYSTEM`
-fi
-
-add-apt-repository -y ppa:webupd8team/java
+add-apt-repository -y ppa:openjdk-r/ppa
 apt-get update
-echo debconf shared/accepted-oracle-license-v1-1 select true | \
-    debconf-set-selections
-echo debconf shared/accepted-oracle-license-v1-1 seen true | \
-    debconf-set-selections
-apt-get install -q -y oracle-java8-installer
-
-rsync -av $JAVA_CACHE_SYSTEM $JAVA_CACHE_VAGRANT
-rm -r $JAVA_CACHE_SYSTEM
+apt-get install -q -y openjdk-8-jdk

--- a/provision/install-java.sh
+++ b/provision/install-java.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -x
+set -ex
 JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 if [ -d $JAVA_HOME ]; then


### PR DESCRIPTION
```
 The Oracle JDK License has changed for releases starting April 16, 2019.

The new Oracle Technology Network License Agreement for Oracle Java SE is substantially different from prior Oracle JDK licenses. The new license permits certain uses, such as personal use and development use, at no cost -- but other uses authorized under prior Oracle JDK licenses may no longer be available. Please review the terms carefully before downloading and using this product. An FAQ is available here: https://www.oracle.com/technetwork/java/javase/overview/oracle-jdk-faqs.html

Oracle Java downloads now require logging in to an Oracle account to download Java updates, like the latest Oracle Java 8u211 / Java SE 8u212. Because of this I cannot update the PPA with the latest Java (and the old links were broken by Oracle).

For this reason, THIS PPA IS DISCONTINUED (unless I find some way around this limitation).

Oracle Java (JDK) Installer (automatically downloads and installs Oracle JDK8). There are no actual Java files in this PPA.
```